### PR TITLE
Daylight savings bug fix

### DIFF
--- a/src/lib/words.ts
+++ b/src/lib/words.ts
@@ -1,9 +1,10 @@
 import { WORDS } from '../constants/wordlist'
 import { VALID_GUESSES } from '../constants/valid-guesses'
 
-// January 1, 2022 Game Epoch
-const EPOCH_START = 1640991600000
+// January 1, 2022 Game Epoch - UTC
+const EPOCH_START = 1640995200000
 const MS_IN_DAY = 86400000
+const OFFSET = new Date().getTimezoneOffset() * 60000
 
 export const isWordInWordList = (word: string) => {
     return WORDS.includes(word.toLowerCase()) || VALID_GUESSES.includes(word.toLowerCase())
@@ -19,12 +20,12 @@ export const isWinningWord = (word: string) => {
 
 export const getWordOfDayIndex = () => {
     const now = Date.now()
-    return Math.floor((now - EPOCH_START) / MS_IN_DAY) % WORDS.length
+    return Math.floor((now - EPOCH_START - OFFSET) / MS_IN_DAY) % WORDS.length
 }
 
 export const getTimeUntilNextWord = () => {
     const solutionIndex = getWordOfDayIndex()
-    const time = EPOCH_START + (solutionIndex + 1) * MS_IN_DAY - Date.now()
+    const time = EPOCH_START + (solutionIndex + 1) * MS_IN_DAY - Date.now() + OFFSET
     const date = new Date(time)
     return {
         hours: (24 + (date.getHours() - 1)) % 24,


### PR DESCRIPTION
Since the daylight savings change (27th March), the new word for the day changes at 01:00 AM CET instead of 00:00 CET.

Changes:

- the game epoch (2022-01-01 00:00:00) was in timezone CET, changed it to UTC (persisting a specific date in UTC is considered best practice _[ref](https://stackoverflow.com/a/2532962/6553931)_)
- take the user's timezone offset and add it to the calculations with the game epoch that's now in UTC, for `getWordOfDayIndex` and `getTimeUntilNextWord` so that the next word appears at midnight